### PR TITLE
Bump ember-cli version to 1.13.8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,17 @@
 {
   "name": "ember-local-forage",
   "dependencies": {
-    "ember": "1.13.5",
+    "ember": "1.13.7",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.7",
+    "ember-data": "1.13.8",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.7",
+    "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "localforage": "~1.2.10",
-    "qunit": "~1.17.1"
+    "jquery": "^1.11.3",
+    "loader.js": "ember-cli/loader.js#3.2.1",
+    "qunit": "~1.18.0",
+    "localforage": "~1.2.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,20 +18,20 @@
   "author": "faizaanshamsi",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "1.13.6",
-    "ember-cli-app-version": "0.4.0",
+    "broccoli-asset-rev": "^2.1.2",
+    "ember-cli": "1.13.8",
+    "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
-    "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.18",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-qunit": "^1.0.0",
     "ember-cli-release": "0.2.3",
-    "ember-cli-sri": "^1.0.1",
-    "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.13.7",
+    "ember-cli-sri": "^1.0.3",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-data": "1.13.8",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",
@@ -42,7 +42,7 @@
     "localforage"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.1.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Bumps ember-cli version to latest release https://github.com/ember-cli/ember-cli/releases/tag/v1.13.8
