### PR TITLE
Add test for localforage exports

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "ember-local-forage",
   "dependencies": {
-    "ember": "1.13.7",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
+    "ember": "2.1.0",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.6",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.8",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
+    "ember-data": "2.1.0",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "1.13.8",
+    "ember-data": "2.1.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",

--- a/tests/unit/utils/localforage-exports-test.js
+++ b/tests/unit/utils/localforage-exports-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import localforage from 'ember-local-forage';
+
+module('Unit | Utility | localforage exports');
+
+test('localforage is exported successfully', function(assert) {
+  assert.ok(localforage, 'localforage is exported');
+});
+
+test('localforage has expected functions', function(assert) {
+  assert.equal(typeof localforage.getItem, 'function',
+    'localforage has a known function on it (getItem)');
+  assert.equal(typeof localforage.getItem, 'function',
+    'localforage has a known function on it (setItem)');
+});


### PR DESCRIPTION
- Adds a test that checks that localforage is exported correctly.
- Adds a test that localforage has known localforage functions
- Updates ember and ember-data to 2.1.0 (release)
