### PR TITLE
Bump localForage to 1.4.0

### DIFF
--- a/blueprints/ember-local-forage/index.js
+++ b/blueprints/ember-local-forage/index.js
@@ -6,7 +6,7 @@ module.exports = {
 
   afterInstall: function(options) {
     return this.addBowerPackagesToProject([
-      { name: 'localforage', target: '~1.2.10' }
+      { name: 'localforage', target: '~1.4.0' }
     ]);
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,6 @@
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
-    "localforage": "~1.2.10"
+    "localforage": "~1.4.0"
   }
 }


### PR DESCRIPTION
This PR simply bumps the `localForage` dependency to the latest version (`1.4.0`).
